### PR TITLE
Update the installation steps on Brew

### DIFF
--- a/pages/docs/install.mdx
+++ b/pages/docs/install.mdx
@@ -54,12 +54,6 @@ sudo xattr -r -d com.apple.quarantine /Applications/Mihomo\ Party.app
 
 Mihomo Party 还可以通过 Homebrew 安装
 
-### 添加 Mihomo Party 的 Tap
-
-```bash
-brew tap mihomo-party-org/mihomo-party
-```
-
 ### 安装
 
 ```bash


### PR DESCRIPTION
It could be installed from official Brew casks for now.

```sh
brew info mihomo-party

==> mihomo-party: 1.7.3
https://mihomo.party/
Installed
/usr/local/Caskroom/mihomo-party/1.7.3 (164.6MB)
  Installed using the formulae.brew.sh API on 2025-04-28 at 19:40:43
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/m/mihomo-party.rb
==> Name
Mihomo Party
==> Description
Another Mihomo GUI
==> Artifacts
mihomo-party-macos-1.7.3-x64.pkg (Pkg)
==> Analytics
install: 155 (30 days), 440 (90 days), 527 (365 days)
```